### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/IronSourceAdapterInterstitialAd.swift
+++ b/Source/IronSourceAdapterInterstitialAd.swift
@@ -63,9 +63,8 @@ extension IronSourceAdapterInterstitialAd: CHBHIronSourceWrapperInterstitialDele
     
     func interstitialDidFailToLoadWithError(_ partnerError: Error, instanceId: String) {
         // Report load failure
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     
@@ -78,9 +77,8 @@ extension IronSourceAdapterInterstitialAd: CHBHIronSourceWrapperInterstitialDele
     
     func interstitialDidFailToShowWithError(_ partnerError: Error, instanceId: String) {
         // Report show failure
-        let error = error(.showFailureUnknown, error: partnerError)
-        log(.showFailed(error))
-        showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+        log(.showFailed(partnerError))
+        showCompletion?(.failure(partnerError)) ?? log(.showResultIgnored)
         showCompletion = nil
     }
     

--- a/Source/IronSourceAdapterRewardedAd.swift
+++ b/Source/IronSourceAdapterRewardedAd.swift
@@ -63,9 +63,8 @@ extension IronSourceAdapterRewardedAd: CHBHIronSourceWrapperRewardedDelegate {
     
     func rewardedVideoDidFailToLoadWithError(_ partnerError: Error, instanceId: String) {
         // Report load failure
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
     
@@ -78,9 +77,8 @@ extension IronSourceAdapterRewardedAd: CHBHIronSourceWrapperRewardedDelegate {
     
     func rewardedVideoDidFailToShowWithError(_ partnerError: Error, instanceId: String) {
         // Report show failure
-        let error = error(.showFailureUnknown, error: partnerError)
-        log(.showFailed(error))
-        showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+        log(.showFailed(partnerError))
+        showCompletion?(.failure(partnerError)) ?? log(.showResultIgnored)
         showCompletion = nil
     }
     


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
