### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Push the podspec.
       - name: Push Podspec
-        run: pod trunk push --verbose
+        run: pod trunk push --verbose --skip-import-validation
 
       # Create GitHub release.
       - name: Create Release


### PR DESCRIPTION
Push podspec with --skip-import-validation to avoid failures due to cocoapods trying to import the pod for excluded architectures