### PR TITLE
Update version to 4.7.3.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.7.3.1.0.0
+- This version of the adapters has been certified with IronSourceSDK 7.3.1.0.
+
 ### 4.7.3.0.0.0
 - Prevent multiple fullscreen loads for the same placement from happening concurrently.
 - This version of the adapters has been certified with IronSourceSDK 7.3.0.0.

--- a/ChartboostMediationAdapterIronSource.podspec
+++ b/ChartboostMediationAdapterIronSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterIronSource'
-  spec.version     = '4.7.3.0.0.0'
+  spec.version     = '4.7.3.1.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-ironsource'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -23,7 +23,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'IronSourceSDK', '~> 7.3.0.0'
+  spec.dependency 'IronSourceSDK', '~> 7.3.1.0'
 
   # IronSource SDK does not support i386 simulators.
   spec.pod_target_xcconfig = { 

--- a/Source/IronSourceAdapter.swift
+++ b/Source/IronSourceAdapter.swift
@@ -16,7 +16,7 @@ final class IronSourceAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.7.3.0.0.0"
+    let adapterVersion = "4.7.3.1.0.0"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "ironsource"


### PR DESCRIPTION
@kendallrogers fixing the branch name closed out [the old pull request](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-ironsource/pull/40). The adapter has been certified and released, I just need a new approval to merge this version bump into `main`