### PR TITLE
[HB-7400] Initialize the SDK on the `main` queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.7.8.0.0.1
+- Initialization of the SDK on the main queue.
+
 ### 4.7.8.0.0.0
 - This version of the adapter has been certified with IronSourceSDK 7.8.0.0.
 

--- a/ChartboostMediationAdapterIronSource.podspec
+++ b/ChartboostMediationAdapterIronSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterIronSource'
-  spec.version     = '4.7.8.0.0.0'
+  spec.version     = '4.7.8.0.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-ironsource'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/IronSourceAdapter.swift
+++ b/Source/IronSourceAdapter.swift
@@ -16,8 +16,8 @@ final class IronSourceAdapter: PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.7.8.0.0.0"
-    
+    let adapterVersion = "4.7.8.0.0.1"
+
     /// The partner's unique identifier.
     let partnerIdentifier = "ironsource"
     
@@ -50,16 +50,21 @@ final class IronSourceAdapter: PartnerAdapter {
             completion(error)
             return
         }
-        // Initialize IronSource
-        IronSource.initISDemandOnly(appKey, adUnits: configuration.lineItems ?? [])
-        
-        // IronSource provides one single delegate for all ads of the same type.
-        // IronSourceAdapterRouter implements these delegate protocols and forwards calls to the corresponding partner ad instances.
+
+        // Initialize IronSource. Must be performed on the main queue.
+        dispatchPrecondition(condition: .notOnQueue(.main)) // If on the main queue, there will be deadlock. Make sure we are not on the main queue.
+        DispatchQueue.main.sync {
+            IronSource.initISDemandOnly(appKey, adUnits: configuration.lineItems ?? [])
+        }
+
         let router = IronSourceAdapterRouter(adapter: self)
         self.router = router    // keep the router instance alive
+
+        // IronSource provides one single delegate for all ads of the same type.
+        // IronSourceAdapterRouter implements these delegate protocols and forwards calls to the corresponding partner ad instances.
         IronSource.setISDemandOnlyInterstitialDelegate(router)
         IronSource.setISDemandOnlyRewardedVideoDelegate(router)
-        
+
         log(.setUpSucceded)
         completion(nil)
     }

--- a/Source/IronSourceAdapter.swift
+++ b/Source/IronSourceAdapter.swift
@@ -52,21 +52,20 @@ final class IronSourceAdapter: PartnerAdapter {
         }
 
         // Initialize IronSource. Must be performed on the main queue.
-        dispatchPrecondition(condition: .notOnQueue(.main)) // If on the main queue, there will be deadlock. Make sure we are not on the main queue.
-        DispatchQueue.main.sync {
+        DispatchQueue.main.async {
             IronSource.initISDemandOnly(appKey, adUnits: configuration.lineItems ?? [])
+
+            let router = IronSourceAdapterRouter(adapter: self)
+            self.router = router    // keep the router instance alive
+
+            // IronSource provides one single delegate for all ads of the same type.
+            // IronSourceAdapterRouter implements these delegate protocols and forwards calls to the corresponding partner ad instances.
+            IronSource.setISDemandOnlyInterstitialDelegate(router)
+            IronSource.setISDemandOnlyRewardedVideoDelegate(router)
+
+            self.log(.setUpSucceded)
+            completion(nil)
         }
-
-        let router = IronSourceAdapterRouter(adapter: self)
-        self.router = router    // keep the router instance alive
-
-        // IronSource provides one single delegate for all ads of the same type.
-        // IronSourceAdapterRouter implements these delegate protocols and forwards calls to the corresponding partner ad instances.
-        IronSource.setISDemandOnlyInterstitialDelegate(router)
-        IronSource.setISDemandOnlyRewardedVideoDelegate(router)
-
-        log(.setUpSucceded)
-        completion(nil)
     }
     
     /// Fetches bidding tokens needed for the partner to participate in an auction.


### PR DESCRIPTION
Modification to the adapter `setUp()` to perform SDK initialization on the `main` queue.