### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-latest
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,6 @@ jobs:
   release-adapter:
     runs-on: macos-13  # Last macOS version to support Xcode 14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2
         with:
           allow-warnings: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,6 +12,6 @@ jobs:
   validate-podspec:
     runs-on: macos-13  # Last macOS version to support Xcode 14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2
         with:
           allow-warnings: true

--- a/Source/IronSourceAdapter.swift
+++ b/Source/IronSourceAdapter.swift
@@ -11,19 +11,27 @@ import IronSource
 final class IronSourceAdapter: PartnerAdapter {
     
     /// The version of the partner SDK.
-    let partnerSDKVersion = IronSource.sdkVersion()
-    
+    var partnerSDKVersion: String {
+        IronSourceAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.7.9.1.0.0"
-    
+    var adapterVersion: String {
+        IronSourceAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "ironsource"
-    
+    var partnerID: String {
+        IronSourceAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "IronSource"
-    
+    var partnerDisplayName: String {
+        IronSourceAdapterConfiguration.partnerDisplayName
+    }
+
     /// Ad storage managed by Chartboost Mediation SDK.
     let storage: PartnerAdapterStorage
     

--- a/Source/IronSourceAdapterConfiguration.swift
+++ b/Source/IronSourceAdapterConfiguration.swift
@@ -10,18 +10,18 @@ import IronSource
 @objc public class IronSourceAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         IronSource.sdkVersion()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.7.9.1.0.0"
+    @objc public static let adapterVersion = "4.7.9.1.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "ironsource"
+    @objc public static let partnerID = "ironsource"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "IronSource"
+    @objc public static let partnerDisplayName = "IronSource"
 }

--- a/Source/IronSourceAdapterConfiguration.swift
+++ b/Source/IronSourceAdapterConfiguration.swift
@@ -1,0 +1,27 @@
+// Copyright 2022-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+import IronSource
+
+/// A list of externally configurable properties pertaining to the partner SDK that can be retrieved and set by publishers.
+@objc public class IronSourceAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        IronSource.sdkVersion()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.7.9.1.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "ironsource"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "IronSource"
+}


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.