### PR TITLE
Early merge of main into release/5.x.x.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 - This version of the adapter has been certified with ChartboostMediationSDK 5.0.0.
 - This version of the adapter has been certified with IronSourceSDK 7.9.1.0.
 
+### 4.8.0.0.0.0
+- This version of the adapter has been certified with IronSourceSDK 8.0.0.0.
+
 ### 4.7.9.1.0.0
 - This version of the adapter has been certified with IronSourceSDK 7.9.1.0.
 

--- a/ChartboostMediationAdapterIronSource.podspec
+++ b/ChartboostMediationAdapterIronSource.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterIronSource'
-  spec.version     = '5.7.9.1.0.0'
+  spec.version     = '5.8.0.0.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-ironsource'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 5.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'IronSourceSDK', '~> 7.9.1.0'
+  spec.dependency 'IronSourceSDK', '~> 8.0.0.0'
 
   # IronSource SDK does not support i386 simulators.
   spec.pod_target_xcconfig = { 

--- a/Source/IronSourceAdapterConfiguration.swift
+++ b/Source/IronSourceAdapterConfiguration.swift
@@ -18,7 +18,7 @@ import IronSource
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc public static let adapterVersion = "4.7.9.1.0.0"
+    @objc public static let adapterVersion = "5.8.0.0.0.0"
 
     /// The partner's unique identifier.
     @objc public static let partnerID = "ironsource"


### PR DESCRIPTION
Merge of main into release/5.x.x.x.. Adapter version strings may or may not be up to date, they need to be changed once we finalize the partner version to release the 5.x adapters with anyway.